### PR TITLE
[fix] Removed enable_pending_purchases on initialization options.

### DIFF
--- a/source/GooglePlayBilling_gml/GooglePlayBilling.yyp
+++ b/source/GooglePlayBilling_gml/GooglePlayBilling.yyp
@@ -25,7 +25,7 @@
   "isEcma":false,
   "LibraryEmitters":[],
   "MetaData":{
-    "IDEVersion":"2026.0.0.16",
+    "IDEVersion":"2026.100.0.1121",
   },
   "name":"GooglePlayBilling",
   "resources":[

--- a/source/GooglePlayBilling_gml/objects/obj_play_billing/Create_0.gml
+++ b/source/GooglePlayBilling_gml/objects/obj_play_billing/Create_0.gml
@@ -44,7 +44,6 @@ billing_all_products = [];
 
 var _init_options = new GooglePlayBillingInitOptions();
 _init_options.enable_auto_service_reconnection = true
-_init_options.enable_pending_purchases = true
 
 //Prepaid
 //_init_options.enable_prepaid_plans = true;


### PR DESCRIPTION
Pending purchases are always available, and the entry has no effect on GooglePlayBillingInitOptions constructor. 